### PR TITLE
Remove miloserdie i zabota

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -51,10 +51,6 @@ clients:
     type: яндекс
     url: mks.stophomelessness.ru
 
-  - name: Милосердие и забота
-    type: вк mcs0741818200
-    url: xn--j1adq.xn-----8kcaeogbuecc7am6akyq5a.xn--p1ai
-
   - name: ТЫ ДОМА
     type: вк mcs7451084416
     url: mks.td-samara.ru


### PR DESCRIPTION
Looks like they don't use MKS right now, and we can remove them from checking.